### PR TITLE
Second API for details and comparison /matchDetails

### DIFF
--- a/src/main/java/com/clm/matching/api/MatchEngineController.java
+++ b/src/main/java/com/clm/matching/api/MatchEngineController.java
@@ -1,7 +1,7 @@
 package com.clm.matching.api;
 
+import com.clm.matching.models.MatchDetailsRequestDTO;
 import com.clm.matching.models.VendorMatchOverviewResponseDTO;
-import com.clm.matching.models.VendorMatchResponseDTO;
 import com.clm.matching.service.MatchEngineService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,9 +22,9 @@ public class MatchEngineController {
         this.matchEngineService = matchEngineService;
     }
 
-    @PostMapping("/match")
-    public ResponseEntity<Map<String, Object>> getMatchResults(@RequestBody Map<Long, List<Long>> userSelections) {
-        Map<String, Object> matchResults = matchEngineService.getMatchResults(userSelections);
+    @PostMapping("/matchDetails")
+    public ResponseEntity<Map<String, Object>> getMatchResults(@RequestBody MatchDetailsRequestDTO matchDetailsRequestDTO) {
+        Map<String, Object> matchResults = matchEngineService.getMatchResults(matchDetailsRequestDTO.getUserSelections(), matchDetailsRequestDTO.getVendorIds());
         return ResponseEntity.ok(matchResults);
     }
 

--- a/src/main/java/com/clm/matching/models/MatchDetailsRequestDTO.java
+++ b/src/main/java/com/clm/matching/models/MatchDetailsRequestDTO.java
@@ -1,0 +1,13 @@
+package com.clm.matching.models;
+
+import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+public class MatchDetailsRequestDTO {
+
+    private Map<Long, List<Long>> userSelections;
+    private List<Long> vendorIds;
+}

--- a/src/main/java/com/clm/matching/models/VendorDetailMatchResponseDTO.java
+++ b/src/main/java/com/clm/matching/models/VendorDetailMatchResponseDTO.java
@@ -11,7 +11,7 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class VendorMatchResponseDTO {
+public class VendorDetailMatchResponseDTO {
 
     private Long id;
     private String name;

--- a/src/main/java/com/clm/matching/processor/MatchEngineProcessor.java
+++ b/src/main/java/com/clm/matching/processor/MatchEngineProcessor.java
@@ -5,7 +5,7 @@ import com.clm.category.models.OptionDTO;
 import com.clm.matching.models.CategoryMatchResponseDTO;
 import com.clm.matching.models.OptionMatchResponseDTO;
 import com.clm.matching.models.VendorMatchOverviewResponseDTO;
-import com.clm.matching.models.VendorMatchResponseDTO;
+import com.clm.matching.models.VendorDetailMatchResponseDTO;
 import com.clm.vendor.models.VendorResponseDTO;
 import org.springframework.stereotype.Component;
 
@@ -35,9 +35,9 @@ public class MatchEngineProcessor {
                 .collect(Collectors.toList());
     }
 
-    public List<VendorMatchResponseDTO> prepareVendorResponses(Map<Long, List<Long>> userSelections,
-                                                          Map<Long, CategoryDTO> categoryMap,
-                                                          List<VendorResponseDTO> vendors) {
+    public List<VendorDetailMatchResponseDTO> prepareVendorResponses(Map<Long, List<Long>> userSelections,
+                                                                     Map<Long, CategoryDTO> categoryMap,
+                                                                     List<VendorResponseDTO> vendors) {
         return vendors.stream()
                 .map(vendor -> {
                     List<CategoryMatchResponseDTO> categoryMatches = prepareCategoryMatches(
@@ -47,7 +47,7 @@ public class MatchEngineProcessor {
 
                     double vendorMatchPercentage = calculateVendorMatchPercentage(categoryMatches);
 
-                    return new VendorMatchResponseDTO(
+                    return new VendorDetailMatchResponseDTO(
                             vendor.getId(),
                             vendor.getName(),
                             vendor.getDescription(),

--- a/src/main/java/com/clm/matching/processor/MatchEngineProcessor.java
+++ b/src/main/java/com/clm/matching/processor/MatchEngineProcessor.java
@@ -128,6 +128,7 @@ public class MatchEngineProcessor {
                             allOptions
                     );
                 })
+                .sorted(Comparator.comparingDouble(VendorMatchOverviewResponseDTO::getMatchPercentage).reversed())
                 .toList();
     }
 

--- a/src/main/java/com/clm/matching/service/MatchEngineService.java
+++ b/src/main/java/com/clm/matching/service/MatchEngineService.java
@@ -1,13 +1,12 @@
 package com.clm.matching.service;
 
 import com.clm.matching.models.VendorMatchOverviewResponseDTO;
-import com.clm.matching.models.VendorMatchResponseDTO;
 
 import java.util.List;
 import java.util.Map;
 
 public interface MatchEngineService {
 
-    Map<String, Object> getMatchResults(Map<Long, List<Long>> userSelections);
+    Map<String, Object> getMatchResults(Map<Long, List<Long>> userSelections, List<Long> vendorIds);
     List<VendorMatchOverviewResponseDTO> getMatchOverview(Map<Long, List<Long>> userSelections);
 }

--- a/src/main/java/com/clm/matching/service/MatchEngineServiceImpl.java
+++ b/src/main/java/com/clm/matching/service/MatchEngineServiceImpl.java
@@ -3,7 +3,7 @@ package com.clm.matching.service;
 import com.clm.category.models.CategoryDTO;
 import com.clm.category.service.CategoryService;
 import com.clm.matching.models.VendorMatchOverviewResponseDTO;
-import com.clm.matching.models.VendorMatchResponseDTO;
+import com.clm.matching.models.VendorDetailMatchResponseDTO;
 import com.clm.matching.processor.MatchEngineProcessor;
 import com.clm.vendor.models.VendorResponseDTO;
 import com.clm.vendor.service.VendorService;
@@ -29,8 +29,8 @@ public class MatchEngineServiceImpl implements MatchEngineService{
     }
 
     @Override
-    public Map<String, Object>  getMatchResults(Map<Long, List<Long>> userSelections) {
-        List<VendorResponseDTO> vendors = vendorService.getAllVendors();
+    public Map<String, Object>  getMatchResults(Map<Long, List<Long>> userSelections, List<Long> vendorIds) {
+        List<VendorResponseDTO> vendors = vendorService.getVendorByIds(vendorIds);
 
         List<CategoryDTO> categories = categoryService.findAll();
 
@@ -38,7 +38,7 @@ public class MatchEngineServiceImpl implements MatchEngineService{
                 .collect(Collectors.toMap(CategoryDTO::getId, Function.identity()));
 
         List<CategoryDTO> filteredCategories = matchEngineProcessor.prepareFilteredCategories(userSelections, categoryMap);
-        List<VendorMatchResponseDTO> vendorResponses = matchEngineProcessor.prepareVendorResponses(userSelections, categoryMap, vendors);
+        List<VendorDetailMatchResponseDTO> vendorResponses = matchEngineProcessor.prepareVendorResponses(userSelections, categoryMap, vendors);
 
         Map<String, Object> response = new HashMap<>();
         response.put("categories", filteredCategories);

--- a/src/main/java/com/clm/vendor/service/VendorService.java
+++ b/src/main/java/com/clm/vendor/service/VendorService.java
@@ -10,6 +10,7 @@ public interface VendorService {
     public VendorResponseDTO createVendor(VendorDTO vendorDTO);
     public VendorResponseDTO getVendor(Long id);
     public List<VendorResponseDTO> getAllVendors();
+    public List<VendorResponseDTO> getVendorByIds(List<Long> ids);
     public VendorResponseDTO updateVendor(Long id, VendorDTO vendorDTO);
     public void deleteVendor(Long id);
 }

--- a/src/main/java/com/clm/vendor/service/VendorServiceImpl.java
+++ b/src/main/java/com/clm/vendor/service/VendorServiceImpl.java
@@ -61,6 +61,19 @@ public class VendorServiceImpl implements VendorService{
     }
 
     @Override
+    public List<VendorResponseDTO> getVendorByIds(List<Long> ids) {
+        List<Vendor> vendors = vendorRepository.findAllById(ids);
+
+        return vendors.stream()
+                .map(vendor -> {
+                    List<CategoryDTO> categoryOptions =
+                            vendorDataProcessor.buildCategoryOptions(vendor);
+                    return vendorMapper.toResponseDTO(vendor, categoryOptions);
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Override
     public VendorResponseDTO updateVendor(Long id, VendorDTO vendorDTO) {
         if (!vendorRepository.existsById(id)) {
             throw new EntityNotFoundException("Vendor not found with id: " + id);


### PR DESCRIPTION
1. Created MatchDetailsRequestDTO 2. Changed Request body to have vendor Ids also so that /matchDetails end point can be used both for single and multiple ids of vendor. Hence can be used for a single vendor match detail and also comparison.